### PR TITLE
add config file for circuit drawer backend

### DIFF
--- a/qiskit-iqx-tutorials/.qiskit/settings.conf
+++ b/qiskit-iqx-tutorials/.qiskit/settings.conf
@@ -1,0 +1,2 @@
+[default]
+circuit_drawer = mpl


### PR DESCRIPTION
Without this, circuits are drawn with ascii.